### PR TITLE
Expose --max-backoff arg to env runtime for Docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,5 +8,6 @@ if [ -n "$CORES" ]; then args+=("--cores" "$CORES"); fi
 if [ -n "$ENDPOINT" ]; then args+=("--endpoint" "$ENDPOINT"); fi
 if [ -n "$USER_BACKLOG" ]; then args+=("--user-backlog" "$USER_BACKLOG"); fi
 if [ -n "$SYSTEM_BACKLOG" ]; then args+=("--system-backlog" "$SYSTEM_BACKLOG"); fi
+if [ -n "$MAX_BACKOFF" ]; then args+=("--max-backoff" "$MAX_BACKOFF"); fi
 
 exec /fishnet "${args[@]}"


### PR DESCRIPTION
For dockerized local dev or ephemeral test environments with low to zero traffic, the 30s default max backoff can make fishnet clients feel sluggish.  _Exposing_ the option shouldn't cause issues & provides a bit more flexibility for docker deployments.