### PR TITLE
Add error message for missing submodule during build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -94,6 +94,12 @@ impl Target {
             "$(CXX) --version"
         );
 
+        assert!(
+            Path::new(src_dir).is_dir(),
+            "Directory {} does not exist. Did you clone with `--recursive` to load submodules?",
+            src_dir
+        );
+
         if flavor == Flavor::Official
             && !Command::new(&make)
                 .current_dir(src_dir)


### PR DESCRIPTION
During `cargo build`, got an error and had to track down why.

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os
  { code: 2, kind: NotFound, message: "No such file or directory" }', build.rs:107:18
```