### PR TITLE
Enable arbitrary user ID at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,9 @@ RUN apk --no-cache add bash
 COPY --from=builder /fishnet/target/x86_64-unknown-linux-musl/release/fishnet /fishnet
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 CMD ["/docker-entrypoint.sh"]
+
+# Set permissions for OpenShift, since there is an arbitrary user ID assigned at runtime. 
+# But this user is member of group ID 0, so we can change permissions to allow working.
+RUN touch /.fishnet-stats && \
+    chgrp -R 0 /.fishnet-stats && \
+    chmod -R 775 /.fishnet-stats


### PR DESCRIPTION
OpenShift assigns an arbitrary user ID at runtime. But this user is a member of group ID 0, so change permissions to enable GID 0. Since the binary is in "/" we cannot change the whole path, but just touch the stats file and set permissions accordingly.