### PR TITLE
OCP documentation & Files

### DIFF
--- a/doc/openshift/README.md
+++ b/doc/openshift/README.md
@@ -1,2 +1,27 @@
 # OpenShift Deployment
 This document describes the steps to launch FishNet on an OpenShift 4 cluster.
+
+## Steps
+1. Create a new project. `project.yaml` can be used.
+2. Create a secret with your FishNet API key. Number of CPU cores to be used can also be set here.
+3. Create a new deployment using the provided `deployment.yaml` file.
+4. Set the replicas/pods to your liking.
+
+### 1. Create a new project 
+We assume, that you are already logged in to your OCP cluster. For simplicity the steps shown in this document refer to the commandline, but can also be done via the OPC GUI.
+
+There are two simple ways to create a new project:
+
+- `oc new-project fishnet` (this command also changes to the project automatically)
+
+or use the provided `project.yaml` file
+- `oc apply -f project.yaml` (you need to change to the new project manually: `oc project fishnet`)
+
+### 2. Create a Secret with your FishNet API key
+Create a secret named `fishnet`:
+
+`oc create secret generic fishnet -n fishnet --from-literal KEY="<Your_API_Key>"`
+
+By default _FishNet_ sets the number of cores to be used to `n-1`. So if you dont want the worker to use this value, you could add a `CORES` value to the secret like this:
+
+`oc create secret generic fishnet -n fishnet --from-literal KEY="<Your_API_Key>" --from-literal CORES="1"`

--- a/doc/openshift/README.md
+++ b/doc/openshift/README.md
@@ -1,14 +1,14 @@
 # OpenShift Deployment
-This document describes the steps to launch FishNet on an OpenShift 4 cluster.
+This document describes the steps to launch _FishNet_ on an _OpenShift 4_ cluster.
 
 ## Steps
 1. Create a new project. `project.yaml` can be used.
-2. Create a secret with your FishNet API key. Number of CPU cores to be used can also be set here.
+2. Create a secret with your _FishNet_ API key. Number of CPU cores to be used can also be set here.
 3. Create a new deployment using the provided `deployment.yaml` file.
-4. Set the replicas/pods to your liking.
+4. Set the number of replicas/pods to your preference.
 
 ### 1. Create a new project 
-We assume, that you are already logged in to your OCP cluster. For simplicity the steps shown in this document refer to the commandline, but can also be done via the OPC GUI.
+We assume, that you are already logged in to your _OCP_ cluster. For simplicity the steps shown in this document refer to the commandline, but can also be done via the _OCP GUI_.
 
 There are two simple ways to create a new project:
 
@@ -22,6 +22,25 @@ Create a secret named `fishnet`:
 
 `oc create secret generic fishnet -n fishnet --from-literal KEY="<Your_API_Key>"`
 
-By default _FishNet_ sets the number of cores to be used to `n-1`. So if you dont want the worker to use this value, you could add a `CORES` value to the secret like this:
+By default _FishNet_ sets the number of cores to be used to `n-1`. So if you dont want the worker to use this value, you could add a `CORES` value to the command like this:
 
 `oc create secret generic fishnet -n fishnet --from-literal KEY="<Your_API_Key>" --from-literal CORES="1"`
+
+### 3. Create a Deployment
+Apply the provided `deployment.yaml` file like this:
+
+`oc apply -f deployment.yaml -n fishnet`
+
+### 4. Check and scale your Deplyoment
+By default there is one _replica_ defined, which results in one _pod_ running. 
+You can check the _deployment_ and the _pods_ like this:
+
+`oc get deployment -n fishnet` and `oc get pods -n fishnet`
+
+To scale the number of _pods_ up and down use this command and provide the number of _replicas_ you want to use:
+
+`oc scale deployment fishnet -n fishnet --replicas=<Number_of_Replicas>`
+
+
+
+

--- a/doc/openshift/README.md
+++ b/doc/openshift/README.md
@@ -1,0 +1,2 @@
+# OpenShift Deployment
+This document describes the steps to launch FishNet on an OpenShift 4 cluster.

--- a/doc/openshift/deployment.yaml
+++ b/doc/openshift/deployment.yaml
@@ -1,0 +1,49 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: fishnet
+  labels:
+    app: fishnet
+    app.kubernetes.io/component: fishnet
+    app.kubernetes.io/instance: fishnet
+    app.kubernetes.io/name: fishnet
+    app.kubernetes.io/part-of: fishnet
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fishnet
+  template:
+    metadata:
+      labels:
+        app: fishnet
+        deployment: fishnet
+    spec:
+      containers:
+        - name: fishnet
+          image: docker.io/niklasf/fishnet:2
+          envFrom:
+            - secretRef:
+                name: fishnet
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/doc/openshift/deployment.yaml
+++ b/doc/openshift/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: fishnet
-          image: docker.io/niklasf/fishnet:2
+          image: docker.io/toughiq/fishnet:multi
           envFrom:
             - secretRef:
                 name: fishnet

--- a/doc/openshift/deployment.yaml
+++ b/doc/openshift/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: fishnet
-          image: docker.io/toughiq/fishnet:multi
+          image: docker.io/niklasf/fishnet:latest
           envFrom:
             - secretRef:
                 name: fishnet

--- a/doc/openshift/project.yaml
+++ b/doc/openshift/project.yaml
@@ -1,0 +1,9 @@
+kind: Project
+apiVersion: project.openshift.io/v1
+metadata:
+  name: fishnet
+  labels:
+    kubernetes.io/metadata.name: fishnet
+  annotations:
+    openshift.io/description: 'FishNet Worker'
+    openshift.io/display-name: 'Fishnet Worker'

--- a/doc/openshift/project.yaml
+++ b/doc/openshift/project.yaml
@@ -6,4 +6,4 @@ metadata:
     kubernetes.io/metadata.name: fishnet
   annotations:
     openshift.io/description: 'FishNet Worker'
-    openshift.io/display-name: 'Fishnet Worker'
+    openshift.io/display-name: 'FishNet Worker'


### PR DESCRIPTION
I created a dedicated subdirectory for this documentation, so I could provide additional files and would not conflict with the current structure.

Although the deployment process would work as described, the container would currently fail, since it refers to the current container image, which currently does not have the permission changes done.

I tested this with my own image (docker.io/toughiq/fishnet:latest) which is just the `fishnet:2` image with the added file permissions.

