### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ exclude = [
 
 [profile.release]
 strip = true
+lto = true
 
 [dependencies]
 arrayvec = "0.7"


### PR DESCRIPTION
Before:

![image](https://github.com/lichess-org/fishnet/assets/57120300/4a5a86ca-5784-415f-8742-98c0df7eb119)

After:

![image](https://github.com/lichess-org/fishnet/assets/57120300/0cb90bb5-0389-4e6a-b823-b5350b547a52)

Binary is slightly smaller and should also be slightly faster

Compilation time was 40s longer with LTO enabled (4m vs 4m 40s)