### PR TITLE
Use aliases instead of global use statements for matching `SkillLevel`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -236,40 +236,40 @@ pub enum SkillLevel {
 
 impl SkillLevel {
     pub fn time(self) -> Duration {
-        use SkillLevel::*;
+        use SkillLevel as s;
         Duration::from_millis(match self {
-            One => 50,
-            Two => 100,
-            Three => 150,
-            Four => 200,
-            Five => 300,
-            Six => 400,
-            Seven => 500,
-            Eight => 1000,
+            s::One => 50,
+            s::Two => 100,
+            s::Three => 150,
+            s::Four => 200,
+            s::Five => 300,
+            s::Six => 400,
+            s::Seven => 500,
+            s::Eight => 1000,
         })
     }
 
     pub fn skill_level(self) -> i32 {
-        use SkillLevel::*;
+        use SkillLevel as s;
         match self {
-            One => -9,
-            Two => -5,
-            Three => -1,
-            Four => 3,
-            Five => 7,
-            Six => 11,
-            Seven => 16,
-            Eight => 20,
+            s::One => -9,
+            s::Two => -5,
+            s::Three => -1,
+            s::Four => 3,
+            s::Five => 7,
+            s::Six => 11,
+            s::Seven => 16,
+            s::Eight => 20,
         }
     }
 
     pub fn depth(self) -> u8 {
-        use SkillLevel::*;
+        use SkillLevel as s;
         match self {
-            One | Two | Three | Four | Five => 5,
-            Six => 8,
-            Seven => 13,
-            Eight => 22,
+            s::One | s::Two | s::Three | s::Four | s::Five => 5,
+            s::Six => 8,
+            s::Seven => 13,
+            s::Eight => 22,
         }
     }
 }


### PR DESCRIPTION
In the case where variants from the `SkillLevel` enum are removed, the match statements will still be valid with the global use, but the arms with the removed elements will now become catch-alls and the compiler warnings that comes from this isn't particularly indicative of anything wrong:
```diff
diff --git a/src/api.rs b/src/api.rs
index 7142975..d8cdc82 100644
--- a/src/api.rs
+++ b/src/api.rs
@@ -231,7 +231,8 @@ pub enum SkillLevel {
     Five = 5,
     Six = 6,
     Seven = 7,
-    Eight = 8,
+    Nine = 9,
+    Ten = 10,
 }

```

```zsh
warning: unreachable pattern
   --> src/api.rs:248:13
    |
248 |             Eight => 1000,
    |             ^^^^^
    |
    = note: `#[warn(unreachable_patterns)]` on by default

warning: unused variable: `Eight`
   --> src/api.rs:248:13
    |
248 |             Eight => 1000,
    |             ^^^^^ help: if this is intentional, prefix it with an underscore: `_Eight`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: variable `Eight` should have a snake case name
   --> src/api.rs:248:13
    |
248 |             Eight => 1000,
    |             ^^^^^ help: convert the identifier to snake case: `eight`
    |
    = note: `#[warn(non_snake_case)]` on by default
```

Whereas by using as alias, the compiler will bonk you for not matching all arms:
```zsh
error[E0599]: no variant or associated item named `Eight` found for enum `SkillLevel` in the current scope
   --> src/api.rs:249:16
    |
226 | pub enum SkillLevel {
    | ------------------- variant or associated item `Eight` not found for this enum
...
249 |             s::Eight => 1000,
    |                ^^^^^ variant or associated item not found in `SkillLevel`

error[E0004]: non-exhaustive patterns: `SkillLevel::Nine` and `SkillLevel::Ten` not covered
   --> src/api.rs:242:37
    |
242 |         Duration::from_millis(match self {
    |                                     ^^^^ patterns `SkillLevel::Nine` and `SkillLevel::Ten` not covered
    |
note: `SkillLevel` defined here
   --> src/api.rs:226:10
    |
226 | pub enum SkillLevel {
    |          ^^^^^^^^^^
...
235 |     Nine = 9,
    |     ---- not covered
236 |     Ten = 10,
    |     --- not covered
    = note: the matched value is of type `SkillLevel`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
250 ~             s::Eight => 1000,
251 ~             SkillLevel::Nine | SkillLevel::Ten => todo!(),
```