### PR TITLE
Allow users to say no when writing to fishnet.ini

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -578,10 +578,27 @@ pub async fn parse_and_configure(client: &Client) -> Opt {
                     .read_line(&mut write)
                     .expect("read confirmation from stdin");
 
-                if let Ok(Toggle::Yes | Toggle::Default) = Toggle::from_str(&write) {
-                    let contents = ini.writes();
-                    fs::write(opt.conf(), contents).expect("write config");
-                    break;
+                match Toggle::from_str(&write) {
+                    Ok(Toggle::Yes | Toggle::Default) => {
+                        let contents = ini.writes();
+                        fs::write(opt.conf(), contents).expect("write config");
+                        break;
+                    }
+                    Ok(Toggle::No) => {
+                        let contents = ini.writes();
+                        eprint!(
+                            "Writing to {:?} is necessary to continue. Exiting.\n",
+                            opt.conf()
+                        );
+                        eprint!("Here is the fishnet.ini contents if you need them:\n");
+                        eprint!("-----------------------------------------------------\n");
+                        eprint!("{}", contents);
+                        eprint!("-----------------------------------------------------\n");
+                        std::process::exit(0);
+                    }
+                    Err(_) => {
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
Got myself in an irritating loop where the user has to say yes.
I understand that writing the file is necessary to provide a service file, but I ended up doing Ctrl+C instead of saying yes.