### PR TITLE
Make mate score validation overflow-safe

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -381,8 +381,23 @@ impl Score {
     pub fn is_plausible(self) -> bool {
         match self {
             Score::Cp(_) => true,
-            Score::Mate(mate) => mate.abs() <= 246, // Stockfish MAX_PLY
+            Score::Mate(mate) => mate.unsigned_abs() <= 246, // Stockfish MAX_PLY
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Score;
+
+    #[test]
+    fn score_plausibility_boundaries() {
+        assert!(Score::Cp(i64::MIN).is_plausible());
+        assert!(Score::Mate(-246).is_plausible());
+        assert!(Score::Mate(246).is_plausible());
+        assert!(!Score::Mate(-247).is_plausible());
+        assert!(!Score::Mate(247).is_plausible());
+        assert!(!Score::Mate(i64::MIN).is_plausible());
     }
 }
 


### PR DESCRIPTION
Use `i64::unsigned_abs` when validating mate scores so `i64::MIN` is rejected instead of overflowing. With overflow checks enabled the previous code could panic; without them it could incorrectly accept the value as plausible.

Add boundary coverage for Stockfish’s ±246 `MAX_PLY` limit, adjacent invalid values, and `i64::MIN`.

Follow-up to #291.

Tests:
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

AI disclosure: Codex helped investigate the score-validation edge case and draft the implementation and tests. I reviewed and directed the work throughout as the human in the loop.