### PR TITLE
Enable feature `reqwest/socks` to support SOCKS proxies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bitflags = "2"
 clap = { version = "4", features = ["derive", "deprecated", "wrap_help"] }
 configparser = "3"
 fastrand = "2"
-reqwest = { version = "0.13", features = ["query", "json", "rustls-no-provider", "stream", "http2", "system-proxy"], default-features = false }
+reqwest = { version = "0.13", features = ["query", "json", "rustls-no-provider", "stream", "http2", "system-proxy", "socks"], default-features = false }
 rustls = { version = "0.23", features = ["ring", "tls12", "logging"], default-features = false } # will fail at runtime if mismatch with reqwest
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Currently only HTTP proxies are supported. Enabling this is pretty much free so why not.